### PR TITLE
chore(lint): remove obsolete ESLint disable comments from test files\…

### DIFF
--- a/backend/src/common/services/logging.service.spec.ts
+++ b/backend/src/common/services/logging.service.spec.ts
@@ -68,7 +68,6 @@ describe('LoggingService', () => {
       expect(new Date(call.timestamp).toISOString()).toBe(call.timestamp);
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid message gracefully', () => {
       (() => service.log('' as any))();
       (() => service.log(null as any))();
@@ -78,7 +77,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(4);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
     it('should sanitize circular reference context', () => {
       const circularObj: any = { name: 'test' };
@@ -149,7 +147,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid message gracefully', () => {
       service.error('' as any);
       service.error(null as any);
@@ -158,7 +155,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.error).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
     it('should handle non-Error objects by throwing an error', () => {
       const message = 'Test error message';
@@ -194,7 +190,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid message gracefully', () => {
       service.warn('' as any);
       service.warn(null as any);
@@ -216,7 +211,6 @@ describe('LoggingService', () => {
       );
       // No structured log should be called
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   });
 
   describe('debug', () => {
@@ -243,7 +237,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid message gracefully', () => {
       service.debug('' as any);
       service.debug(null as any);
@@ -252,7 +245,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.debug).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   });
 
   describe('logPerformance', () => {
@@ -302,7 +294,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid operation gracefully', () => {
       service.logPerformance('' as any, 100);
       service.logPerformance(null as any, 100);
@@ -311,9 +302,7 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid duration gracefully', () => {
       service.logPerformance('test', -1);
       service.logPerformance('test', 'invalid' as any);
@@ -322,7 +311,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   });
 
   describe('logDatabaseOperation', () => {
@@ -377,7 +365,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid operation gracefully', () => {
       service.logDatabaseOperation('' as any, 'test');
       service.logDatabaseOperation(null as any, 'test');
@@ -386,9 +373,7 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid table gracefully', () => {
       service.logDatabaseOperation('SELECT', '' as any);
       service.logDatabaseOperation('SELECT', null as any);
@@ -397,9 +382,7 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid duration gracefully', () => {
       service.logDatabaseOperation('SELECT', 'test', -1);
       service.logDatabaseOperation('SELECT', 'test', 'invalid' as any);
@@ -407,7 +390,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(2);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
     it('should allow undefined duration', () => {
       service.logDatabaseOperation('SELECT', 'test', undefined);
@@ -493,7 +475,6 @@ describe('LoggingService', () => {
       });
     });
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid source gracefully', () => {
       service.logScrapingOperation('' as any, 10);
       service.logScrapingOperation(null as any, 10);
@@ -502,9 +483,7 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid jobsFound gracefully', () => {
       service.logScrapingOperation('test', -1);
       service.logScrapingOperation('test', 'invalid' as any);
@@ -513,9 +492,7 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     it('should handle invalid duration gracefully', () => {
       service.logScrapingOperation('test', 10, -1);
       service.logScrapingOperation('test', 10, 'invalid' as any);
@@ -524,7 +501,6 @@ describe('LoggingService', () => {
       expect(mockLogger.warn).toHaveBeenCalledTimes(3);
       expect(mockLogger.log).not.toHaveBeenCalled();
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
     it('should allow undefined duration', () => {
       service.logScrapingOperation('test', 10, undefined);

--- a/backend/src/repositories/job.repository.spec.ts
+++ b/backend/src/repositories/job.repository.spec.ts
@@ -58,7 +58,6 @@ describe('JobRepository', () => {
   });
 
   it('should call prisma.job.create on createJob', async () => {
-    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     const data = {
       title: 'Test',
       company: 'TestCo',
@@ -73,7 +72,6 @@ describe('JobRepository', () => {
     };
     await repository.createJob(data as any);
     expect(mockPrismaService.job.create).toHaveBeenCalledWith({ data });
-    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   });
 
   describe('createJob', () => {
@@ -102,7 +100,6 @@ describe('JobRepository', () => {
     });
 
     it('should handle create job errors', async () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       const jobData = { title: 'Test' } as any;
       const error = new Error('Database error');
       mockPrismaService.job.create.mockRejectedValue(error);
@@ -113,7 +110,6 @@ describe('JobRepository', () => {
       expect(mockPrismaService.job.create).toHaveBeenCalledWith({
         data: jobData,
       });
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -516,7 +512,6 @@ describe('JobRepository', () => {
     });
 
     it('should handle upsert job errors', async () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       const jobData = { title: 'Test' } as any;
       const error = new Error('Database error');
       mockPrismaService.job.upsert.mockRejectedValue(error);
@@ -529,7 +524,6 @@ describe('JobRepository', () => {
         update: jobData,
         create: jobData,
       });
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 

--- a/backend/src/scrapers/arbeitnow/v1/arbeitnow-v1.parser.spec.ts
+++ b/backend/src/scrapers/arbeitnow/v1/arbeitnow-v1.parser.spec.ts
@@ -56,10 +56,8 @@ describe('ArbeitnowV1Parser', () => {
     });
 
     it('should return empty array on parse error', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       const jobs = parser.parseJobs(null as any);
       expect(jobs).toEqual([]);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -70,10 +68,8 @@ describe('ArbeitnowV1Parser', () => {
       expect(parser.parseJobCard(card!)).toBeNull();
     });
     it('should handle error in job card parsing gracefully', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       // Simulate error by passing undefined
       expect(parser.parseJobCard(undefined as any)).toBeNull();
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -244,9 +240,7 @@ describe('ArbeitnowV1Parser', () => {
       expect(parser.hasNextPage(html)).toBe(false);
     });
     it('should handle error and return false', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.hasNextPage(undefined as any)).toBe(false);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -262,9 +256,7 @@ describe('ArbeitnowV1Parser', () => {
       expect(parser.getCurrentPage(html)).toBe(1);
     });
     it('should handle error and return 1', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.getCurrentPage(undefined as any)).toBe(1);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 });

--- a/backend/src/scrapers/relocate/v1/relocate-v1.parser.spec.ts
+++ b/backend/src/scrapers/relocate/v1/relocate-v1.parser.spec.ts
@@ -48,10 +48,8 @@ describe('RelocateV1Parser', () => {
     });
 
     it('should return empty array on parse error', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       const jobs = parser.parseJobs(null as any);
       expect(jobs).toEqual([]);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -62,9 +60,7 @@ describe('RelocateV1Parser', () => {
       expect(parser.parseJobCard(card!)).toBeNull();
     });
     it('should handle error in job card parsing gracefully', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.parseJobCard(undefined as any)).toBeNull();
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
     it('should parse job card directly', () => {
       const html = `<div class="job-card">
@@ -295,9 +291,7 @@ describe('RelocateV1Parser', () => {
       expect(parser.hasNextPage(html)).toBe(false);
     });
     it('should handle error and return false', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.hasNextPage(undefined as any)).toBe(false);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -313,9 +307,7 @@ describe('RelocateV1Parser', () => {
       expect(parser.getCurrentPage(html)).toBe(1);
     });
     it('should handle error and return 1', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.getCurrentPage(undefined as any)).toBe(1);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 });

--- a/backend/src/scrapers/remoteok/v1/remoteok-v1.parser.spec.ts
+++ b/backend/src/scrapers/remoteok/v1/remoteok-v1.parser.spec.ts
@@ -61,10 +61,8 @@ describe('RemoteOKV1Parser', () => {
       expect(jobs[0].sourceId).toBe('backend-dev-globex');
     });
     it('should return empty array on parse error', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       const jobs = parser.parseJobs(null as any);
       expect(jobs).toEqual([]);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -75,9 +73,7 @@ describe('RemoteOKV1Parser', () => {
       expect(parser.parseJobCard(card!)).toBeNull();
     });
     it('should handle error in job card parsing gracefully', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.parseJobCard(undefined as any)).toBeNull();
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -178,9 +174,7 @@ describe('RemoteOKV1Parser', () => {
       expect(parser.hasNextPage(html)).toBe(false);
     });
     it('should handle error and return false', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.hasNextPage(undefined as any)).toBe(false);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 
@@ -196,9 +190,7 @@ describe('RemoteOKV1Parser', () => {
       expect(parser.getCurrentPage(html)).toBe(1);
     });
     it('should handle error and return 1', () => {
-      /* eslint-disable @typescript-eslint/no-unsafe-argument */
       expect(parser.getCurrentPage(undefined as any)).toBe(1);
-      /* eslint-enable @typescript-eslint/no-unsafe-argument */
     });
   });
 });

--- a/backend/src/test/jest-integration.setup.ts
+++ b/backend/src/test/jest-integration.setup.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 beforeAll(async () => {
   // Set test environment
   process.env.NODE_ENV = 'test';
-  
+
   // Use a local SQLite test database
   const testDbPath = path.resolve(process.cwd(), 'test.db');
   process.env.DATABASE_URL = `file:${testDbPath}`;
@@ -22,14 +22,14 @@ beforeAll(async () => {
     // Use prisma db push to create the database schema
     execSync('npx prisma db push --force-reset --accept-data-loss', {
       stdio: 'pipe',
-      env: { 
-        ...process.env, 
+      env: {
+        ...process.env,
         DATABASE_URL: `file:${testDbPath}`,
-        NODE_ENV: 'test'
+        NODE_ENV: 'test',
       },
-      cwd: process.cwd()
+      cwd: process.cwd(),
     });
-    
+
     console.log('✅ Test database created successfully');
   } catch (error) {
     console.error('❌ Error setting up test database:', error);
@@ -55,7 +55,7 @@ afterAll(async () => {
   } catch (error) {
     console.error('❌ Error closing integration test app:', error);
   }
-  
+
   // Clean up test database
   const testDbPath = path.resolve(process.cwd(), 'test.db');
   if (fs.existsSync(testDbPath)) {


### PR DESCRIPTION
## 🧹 Final Linting Cleanup

### ✨ **What's Changed**
- Remove obsolete `@typescript-eslint/no-unsafe-argument` disable comments from test files
- These are no longer needed since we updated ESLint config to allow them in test files
- Minor formatting fixes in `jest-integration.setup.ts`

### �� **Why This Change?**
- Clean up code by removing unnecessary ESLint disable comments
- Maintain consistent code style across test files
- No functional changes - purely cosmetic improvements

### ✅ **Impact**
- No production code changes
- All tests still pass
- Linting is cleaner and more consistent
- Ready for merge to develop

### �� **Files Changed**
- `src/common/services/logging.service.spec.ts`
- `src/repositories/job.repository.spec.ts` 
- `src/scrapers/*/v1/*.parser.spec.ts`
- `src/test/jest-integration.setup.ts`

### �� **Branch Status**
- ✅ **Main:** Up to date with all integration test infrastructure
- ✅ **Develop:** Synced with main (just updated)
- ✅ **Feature Branch:** Has this final cleanup commit

---